### PR TITLE
Add interactive food vending map site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# first-repo
+# Voedselautomatenkaart
 
-Add first line to Readme
+Een kleine webapp met een interactieve kaart (Leaflet + OpenStreetMap) waarop voedselautomaten in Nederland zichtbaar zijn. Pas de dataset in `app.js` aan om jouw volledige lijst te tonen.
 
-Add second line to Readme
+## Starten
 
-Once upon a time in a galaxy far away.
+Open `index.html` direct in de browser, of start een lokale server:
+
+```bash
+python -m http.server
+```

--- a/app.js
+++ b/app.js
@@ -1,0 +1,156 @@
+const locations = [
+  {
+    name: "De Bessenhof",
+    category: "fruit",
+    address: "Bergschenhoek, Zuid-Holland",
+    lat: 51.9906,
+    lng: 4.512,
+    products: ["Aardbeien", "Kersen", "Blauwe bessen"],
+  },
+  {
+    name: "MelkTap Noord",
+    category: "dairy",
+    address: "Groningen, Groningen",
+    lat: 53.2194,
+    lng: 6.5665,
+    products: ["Verse melk", "Yoghurt"],
+  },
+  {
+    name: "Boerderij De Weide",
+    category: "mixed",
+    address: "Barneveld, Gelderland",
+    lat: 52.1405,
+    lng: 5.5846,
+    products: ["Eieren", "Kaas", "Vlees"],
+  },
+  {
+    name: "Vleesautomaat De Hoeve",
+    category: "meat",
+    address: "Tilburg, Noord-Brabant",
+    lat: 51.5606,
+    lng: 5.0919,
+    products: ["Hamburgers", "Worst", "Steak"],
+  },
+  {
+    name: "Groentehal IJssel",
+    category: "fruit",
+    address: "Deventer, Overijssel",
+    lat: 52.255,
+    lng: 6.1636,
+    products: ["Aardappels", "Sla", "Paprika"],
+  },
+  {
+    name: "Kaasautomaat De Polder",
+    category: "dairy",
+    address: "Alkmaar, Noord-Holland",
+    lat: 52.6324,
+    lng: 4.7534,
+    products: ["Oudekaas", "Jonge kaas"],
+  },
+];
+
+const categoryLabels = {
+  fruit: "Fruit & groente",
+  dairy: "Zuivel",
+  meat: "Vlees",
+  mixed: "Gemengd",
+};
+
+const markerColors = {
+  fruit: "#f15a5a",
+  dairy: "#38bdf8",
+  meat: "#f59e0b",
+  mixed: "#10b981",
+};
+
+const map = L.map("map", {
+  zoomControl: false,
+}).setView([52.1326, 5.2913], 7.2);
+
+L.control.zoom({ position: "bottomright" }).addTo(map);
+
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  attribution: "© OpenStreetMap-bijdragers",
+  maxZoom: 18,
+}).addTo(map);
+
+const markersLayer = L.layerGroup().addTo(map);
+
+const statsEl = document.getElementById("stats");
+const categoryFilter = document.getElementById("categoryFilter");
+const searchInput = document.getElementById("searchInput");
+const updatedEl = document.getElementById("updated");
+
+const categories = Array.from(
+  new Set(locations.map((location) => location.category))
+).sort();
+
+categories.forEach((category) => {
+  const option = document.createElement("option");
+  option.value = category;
+  option.textContent = categoryLabels[category] ?? category;
+  categoryFilter.appendChild(option);
+});
+
+const formatPopup = (location) => {
+  return `
+    <div class="popup">
+      <strong>${location.name}</strong><br />
+      <span>${location.address}</span><br />
+      <em>${categoryLabels[location.category] ?? location.category}</em>
+      <ul>
+        ${location.products.map((product) => `<li>${product}</li>`).join("")}
+      </ul>
+    </div>
+  `;
+};
+
+const createMarker = (location) => {
+  const marker = L.circleMarker([location.lat, location.lng], {
+    radius: 9,
+    color: markerColors[location.category] ?? "#16a34a",
+    fillColor: markerColors[location.category] ?? "#16a34a",
+    fillOpacity: 0.85,
+    weight: 2,
+  });
+
+  marker.bindPopup(formatPopup(location));
+  return marker;
+};
+
+const renderMarkers = (data) => {
+  markersLayer.clearLayers();
+  data.forEach((location) => createMarker(location).addTo(markersLayer));
+
+  statsEl.innerHTML = `
+    <span>Actieve locaties</span>
+    <strong>${data.length}</strong>
+  `;
+};
+
+const applyFilters = () => {
+  const selectedCategory = categoryFilter.value;
+  const query = searchInput.value.trim().toLowerCase();
+
+  const filtered = locations.filter((location) => {
+    const matchesCategory =
+      selectedCategory === "all" || location.category === selectedCategory;
+    const matchesQuery =
+      query === "" || location.name.toLowerCase().includes(query);
+
+    return matchesCategory && matchesQuery;
+  });
+
+  renderMarkers(filtered);
+};
+
+categoryFilter.addEventListener("change", applyFilters);
+searchInput.addEventListener("input", applyFilters);
+
+renderMarkers(locations);
+
+updatedEl.textContent = new Date().toLocaleDateString("nl-NL", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric",
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Voedselautomaten in Nederland</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="app__header">
+        <div>
+          <h1>Voedselautomaten in Nederland</h1>
+          <p>Ontdek 24/7 automaten met verse producten in jouw buurt. Klik op een pin voor details.</p>
+        </div>
+        <div class="app__stats" id="stats"></div>
+      </header>
+
+      <main class="app__main">
+        <section class="app__panel">
+          <h2>Filters</h2>
+          <label class="filter">
+            <span>Toon alleen categorie</span>
+            <select id="categoryFilter">
+              <option value="all">Alle categorieën</option>
+            </select>
+          </label>
+          <label class="filter">
+            <span>Zoek op naam</span>
+            <input id="searchInput" type="search" placeholder="Bijv. Aardbeienautomaat" />
+          </label>
+          <div class="legend">
+            <h3>Legenda</h3>
+            <ul>
+              <li><span class="dot dot--fruit"></span> Fruit &amp; groente</li>
+              <li><span class="dot dot--dairy"></span> Zuivel</li>
+              <li><span class="dot dot--meat"></span> Vlees</li>
+              <li><span class="dot dot--mixed"></span> Gemengd</li>
+            </ul>
+          </div>
+          <div class="data-hint">
+            <p>Deze demo bevat voorbeeldlocaties. Voeg je eigen dataset toe in <code>app.js</code> om alle automaten te tonen.</p>
+          </div>
+        </section>
+
+        <section class="app__map" aria-label="Kaart met voedselautomaten">
+          <div id="map"></div>
+        </section>
+      </main>
+
+      <footer class="app__footer">
+        <span>Bron: OpenStreetMap</span>
+        <span>Laatste update: <time id="updated"></time></span>
+      </footer>
+    </div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,187 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  --bg: #f7f7f8;
+  --panel: #ffffff;
+  --accent: #2f6f4e;
+  --accent-dark: #224f38;
+  --muted: #5b6470;
+  --border: #e1e5ea;
+  --shadow: 0 12px 24px rgba(20, 28, 38, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: #111827;
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem 2.5rem 1.5rem;
+}
+
+.app__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 2vw, 2.2rem);
+}
+
+.app__header p {
+  margin: 0;
+  color: var(--muted);
+  max-width: 32rem;
+}
+
+.app__stats {
+  background: var(--panel);
+  padding: 1rem 1.5rem;
+  border-radius: 1rem;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+  min-width: 12rem;
+  text-align: right;
+}
+
+.app__stats strong {
+  display: block;
+  font-size: 1.5rem;
+  color: var(--accent-dark);
+}
+
+.app__main {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.app__panel {
+  background: var(--panel);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.app__panel h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.filter select,
+.filter input {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  font-size: 1rem;
+}
+
+.legend {
+  border-top: 1px dashed var(--border);
+  padding-top: 1rem;
+}
+
+.legend ul {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.dot {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot--fruit {
+  background: #f15a5a;
+}
+
+.dot--dairy {
+  background: #38bdf8;
+}
+
+.dot--meat {
+  background: #f59e0b;
+}
+
+.dot--mixed {
+  background: #10b981;
+}
+
+.data-hint {
+  background: #f0f7f3;
+  border-radius: 0.75rem;
+  padding: 0.9rem;
+  font-size: 0.9rem;
+  color: #365c45;
+}
+
+.app__map {
+  border-radius: 1.5rem;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  min-height: 500px;
+}
+
+#map {
+  width: 100%;
+  height: 100%;
+  min-height: 520px;
+}
+
+.app__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .app__main {
+    grid-template-columns: 1fr;
+  }
+
+  .app__stats {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a simple, static web app to visualise food vending machines across the Netherlands on an interactive map. 
- Make it easy to customise the dataset by keeping sample locations in a single file (`app.js`).
- Ship a polished demo with filtering, legend and usage instructions so it can be opened locally or deployed as a static site.

### Description

- Add `index.html` which boots a Leaflet map, includes controls and a panel for filters, legend and stats. 
- Add `app.js` containing sample `locations`, category labels, marker styling, popup formatting, client-side filtering and stats rendering. 
- Add `style.css` with layout and UI styles for the app shell, panel, legend and map container. 
- Update `README.md` with a project description and a quick start note showing how to run the site with `python -m http.server`.

### Testing

- Started a local HTTP server with `python -m http.server` serving the files on port 8000 which ran successfully. 
- Loaded the page via a Playwright script and captured a screenshot (artifact: `/tmp/codex_browser_invocations/13d7abbb714175df/artifacts/artifacts/voedselautomaten-kaart.png`) which completed successfully. 
- No unit tests were added for this static demo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f0a372ccc832c8cf066015e88cabf)